### PR TITLE
Add JavaScript syllabus overview

### DIFF
--- a/JavaScript-Syllabus.md
+++ b/JavaScript-Syllabus.md
@@ -1,0 +1,48 @@
+# JavaScript Syllabus
+
+## Fundamentals
+- What is JavaScript and where it runs
+- Setting up Node.js and the browser console
+- Including scripts with `<script>`, `defer` and `async`
+
+## Core Concepts
+- Variables (`var`, `let`, `const`) and scope
+- Primitive and reference data types
+- Operators and expressions
+- Control flow with conditionals and loops
+
+## Functions
+- Declarations vs expressions
+- Arrow functions and `this`
+- Parameters, return values and closures
+
+## Working with Data
+- Arrays and common array methods
+- Objects and object manipulation
+- JSON and serialization
+
+## The Browser
+- DOM selection and manipulation
+- Events and event listeners
+- Browser storage: `localStorage` and `sessionStorage`
+
+## Asynchronous JavaScript
+- Callbacks and callback hell
+- Promises and `.then()` chaining
+- `async`/`await` and error handling with `try/catch`
+
+## Modules and Tooling
+- ES modules and `import`/`export`
+- npm scripts and package management
+- Transpiling with Babel and bundling with Webpack/Vite
+
+## Testing and Debugging
+- Using browser DevTools
+- Unit testing with Jest
+- Linting and formatting with ESLint and Prettier
+
+## Advanced Topics
+- Fetch API and HTTP requests
+- Web APIs like `setTimeout` and `fetch`
+- Performance optimization and security basics
+


### PR DESCRIPTION
## Summary
- add concise JavaScript syllabus covering fundamentals, browser APIs, async patterns, modules, tooling and testing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd6a786108324be01fcf8f9dc824b